### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/tombh6/b2ca85c4-952e-4aea-a6e5-023724961805/e18b3962-3045-4657-b879-927ff1e6ddeb/_apis/work/boardbadge/47362ca4-3b54-4c1f-8c7f-bf9966043651)](https://dev.azure.com/tombh6/b2ca85c4-952e-4aea-a6e5-023724961805/_boards/board/t/e18b3962-3045-4657-b879-927ff1e6ddeb/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/tombh6/b2ca85c4-952e-4aea-a6e5-023724961805/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.